### PR TITLE
Fix argument type namespace for proxy compatibility

### DIFF
--- a/common/src/main/java/dev/ftb/mods/ftbteams/FTBTeams.java
+++ b/common/src/main/java/dev/ftb/mods/ftbteams/FTBTeams.java
@@ -44,8 +44,8 @@ public class FTBTeams {
 	}
 
 	public void setup() {
-		ArgumentTypes.register("ftbteams_team", TeamArgument.class, new EmptyArgumentSerializer<>(TeamArgument::create));
-		ArgumentTypes.register("ftbteams_team_property", TeamPropertyArgument.class, new EmptyArgumentSerializer<>(TeamPropertyArgument::create));
+		ArgumentTypes.register("ftbteams:team", TeamArgument.class, new EmptyArgumentSerializer<>(TeamArgument::create));
+		ArgumentTypes.register("ftbteams:team_property", TeamPropertyArgument.class, new EmptyArgumentSerializer<>(TeamPropertyArgument::create));
 	}
 
 	private void serverAboutToStart(MinecraftServer server) {


### PR DESCRIPTION
FTB Teams doesn't currently work on Minecraft proxies such as [Velocity](https://velocitypowered.com/) because it registers its argument types under the `minecraft` namespace which is reserved for the base game only.

This change will render clients and servers running an older version of the mod incompatible with newer versions of the mod.